### PR TITLE
add space to select selector

### DIFF
--- a/addon/helpers/register-select-helper.js
+++ b/addon/helpers/register-select-helper.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default function() {
   Ember.Test.registerAsyncHelper('select', function(app, selector, text) {
-    var $el = app.testHelpers.findWithAssert(selector + "option:contains('" + text + "')");
+    var $el = app.testHelpers.findWithAssert(selector + " option:contains('" + text + "')");
 
     $el.each(function() {
       var _this = this;


### PR DESCRIPTION
I was getting an error like: `Error: Element .my-select-thingoption:contains('what') not found.`
So I tried `select(".my-select-thing ", "what")` and it worked :space_invader: 

