### PR TITLE
Use block params

### DIFF
--- a/app/templates/components/x-select.hbs
+++ b/app/templates/components/x-select.hbs
@@ -4,7 +4,7 @@
   {{#if placeholder}}
     <option>{{placeholder}}</option>
   {{/if}}
-  {{#each option in _optionValues}}
+  {{#each _optionValues as |option|}}
     {{#x-option value=option.value}}{{option.label}}{{/x-option}}
   {{/each}}
 {{/if}}


### PR DESCRIPTION
Was firing a deprecation warning with Ember 1.13. Simple fix use `each as` rather than `each in`