### PR TITLE
Clean up some Glimmer deprecations

### DIFF
--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -52,10 +52,12 @@ export default Ember.Component.extend({
   didInsertElement: function() {
     this._super.apply(this, arguments);
 
-    var select = this.nearestOfType(XSelectComponent);
-    Ember.assert("x-option component declared without enclosing x-select", !!select);
-    this.set('select', select);
-    select.registerOption(this);
+    Ember.run.scheduleOnce('afterRender', () => {
+      var select = this.nearestOfType(XSelectComponent);
+      Ember.assert("x-option component declared without enclosing x-select", !!select);
+      this.set('select', select);
+      select.registerOption(this);
+    });
   },
 
   /**

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -130,36 +130,18 @@ export default Ember.Component.extend({
   }),
 
   /**
-   * Listen for change events on the native <select> element, which
-   * indicates that the user has chosen a new option from the
-   * dropdown. If there is an associated `x-option` component that is
-   * selected, then the overall value of `x-select` becomes the value
-   * of that option.
-   *
-   * @override
+   * When the select DOM event fires on the element, trigger the
+   * component's action with the current value.
    */
-  didInsertElement: function() {
-    this._super.apply(this, arguments);
-
-    this.$().on('change', Ember.run.bind(this, function() {
-      this._contentDidChange();
-    }));
-  },
-
-  /**
-   * Triggers an update of the selected options.
-   * Observing `content` ensures that if an element is removed that
-   * is also part of the selection, selection is cleared.
-   *
-   * @private
-   */
-  _contentDidChange: Ember.observer('content.@each', function() {
+  change() {
     if (this.get('multiple')) {
       this._updateValueMultiple();
     } else {
       this._updateValueSingle();
     }
-  }),
+
+    this.sendAction('action', this.get('value'), this);
+  },
 
   /**
    * Updates `value` with the object associated with the selected option tag
@@ -195,7 +177,6 @@ export default Ember.Component.extend({
     } else {
       this.set('value', newValues);
     }
-    this.raiseAction();
   },
 
   /**
@@ -204,20 +185,9 @@ export default Ember.Component.extend({
   willDestroyElement: function() {
     this._super.apply(this, arguments);
 
-    this.$().off('change');
     // might be overkill, but make sure options can get gc'd
     this.get('options').clear();
   },
-
-  /**
-   * XSelect supports both two-way binding as well as an action. Observe the
-   * `value` property, and when it changes, raise that as an action.
-   *
-   * @private
-   */
-  raiseAction: Ember.observer('value', function() {
-    this.sendAction('action', this.get('value'), this);
-  }),
 
   /**
    * If this is a multi-select, and the value is not an array, that

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -24,7 +24,7 @@ var isArray = Ember.isArray;
 export default Ember.Component.extend({
   tagName: "select",
   classNameBindings: [":x-select"],
-  attributeBindings: ['disabled', 'tabindex', 'multiple', 'name', 'autofocus', 'form', 'required', 'size'],
+  attributeBindings: ['disabled', 'tabindex', 'multiple', 'name', 'autofocus', 'required', 'size'],
 
   /**
    * Bound to the `disabled` attribute on the native <select> tag.
@@ -127,6 +127,10 @@ export default Ember.Component.extend({
    */
   options: Ember.computed(function() {
     return Ember.A();
+  }),
+
+  _setFormAttribute: Ember.on('didRender', function() {
+    this.$().attr('form', this.get('form'));
   }),
 
   /**

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -156,7 +156,7 @@ export default Ember.Component.extend({
     if (option) {
       this.set('value', option.get('value'));
     } else {
-      this.set('value', undefined);
+      this.set('value', null);
     }
   },
 

--- a/app/templates/components/x-select.hbs
+++ b/app/templates/components/x-select.hbs
@@ -1,4 +1,4 @@
-{{#if template}}
+{{#if hasBlock}}
   {{yield}}
 {{else}}
   {{#if placeholder}}

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "emberx-select",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.10.0",
+    "ember": "1.13.2",
     "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "2.0.6",
     "ember-cli": "0.2.7",
-    "ember-cli-app-version": "0.3.2",
+    "ember-cli-app-version": "0.4.0",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-htmlbars": "0.7.4",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -22,7 +22,8 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "getComponentById"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/x-select-multiple-blockless-test.js
+++ b/tests/acceptance/x-select-multiple-blockless-test.js
@@ -17,7 +17,7 @@ describe('XSelect: Multiple Selection', function() {
   });
   beforeEach(function() {
     var el = Ember.$('select');
-    component = Ember.View.views[el.attr('id')];
+    component = getComponentById(el.attr('id'));
     this.$ = function() {
       return component.$.apply(component, arguments);
     };

--- a/tests/acceptance/x-select-multiple-blockless-test.js
+++ b/tests/acceptance/x-select-multiple-blockless-test.js
@@ -9,7 +9,7 @@ import { bastion, stanley, charles } from 'dummy/mixins/folks';
 
 var App;
 
-describe('XSelect: Multiple Selection', function() {
+describe('XSelect: Multiple Selection (Blockless)', function() {
   var component, controller;
   beforeEach(function() {
     App = startApp();

--- a/tests/acceptance/x-select-multiple-test.js
+++ b/tests/acceptance/x-select-multiple-test.js
@@ -17,7 +17,7 @@ describe('XSelect: Multiple Selection', function() {
   });
   beforeEach(function() {
     var el = Ember.$('select');
-    component = Ember.View.views[el.attr('id')];
+    component = getComponentById(el.attr('id'));
     this.$ = function() {
       return component.$.apply(component, arguments);
     };

--- a/tests/acceptance/x-select-single-blockless-option-value-test.js
+++ b/tests/acceptance/x-select-single-blockless-option-value-test.js
@@ -89,7 +89,7 @@ describe('XSelect: Single Selection Blockless w/ Option Value', function() {
       this.$().prop('selectedIndex', 4).trigger('change');
     });
     it("has no value", function() {
-      expect(controller.get('tagged')).to.equal(undefined);
+      expect(controller.get('tagged')).to.equal(null);
     });
   });
 

--- a/tests/acceptance/x-select-single-blockless-option-value-test.js
+++ b/tests/acceptance/x-select-single-blockless-option-value-test.js
@@ -17,7 +17,7 @@ describe('XSelect: Single Selection Blockless w/ Option Value', function() {
   });
   beforeEach(function() {
     var el = Ember.$('select');
-    component = Ember.View.views[el.attr('id')];
+    component = getComponentById(el.attr('id'));
     this.$ = function() {
       return component.$.apply(component, arguments);
     };

--- a/tests/acceptance/x-select-single-blockless-test.js
+++ b/tests/acceptance/x-select-single-blockless-test.js
@@ -17,7 +17,7 @@ describe('XSelect: Single Selection Blockless', function() {
   });
   beforeEach(function() {
     var el = Ember.$('select');
-    component = Ember.View.views[el.attr('id')];
+    component = getComponentById(el.attr('id'));
     this.$ = function() {
       return component.$.apply(component, arguments);
     };

--- a/tests/acceptance/x-select-single-blockless-test.js
+++ b/tests/acceptance/x-select-single-blockless-test.js
@@ -84,7 +84,7 @@ describe('XSelect: Single Selection Blockless', function() {
       this.$().prop('selectedIndex', 4).trigger('change');
     });
     it("has no value", function() {
-      expect(controller.get('tagged')).to.equal(undefined);
+      expect(controller.get('tagged')).to.equal(null);
     });
   });
 

--- a/tests/acceptance/x-select-single-test.js
+++ b/tests/acceptance/x-select-single-test.js
@@ -17,7 +17,7 @@ describe('XSelect: Single Selection', function() {
   });
   beforeEach(function() {
     var el = Ember.$('select');
-    component = Ember.View.views[el.attr('id')];
+    component = getComponentById(el.attr('id'));
     this.$ = function() {
       return component.$.apply(component, arguments);
     };

--- a/tests/acceptance/x-select-single-test.js
+++ b/tests/acceptance/x-select-single-test.js
@@ -79,7 +79,7 @@ describe('XSelect: Single Selection', function() {
       this.$().prop('selectedIndex', 4).trigger('change');
     });
     it("has no value", function() {
-      expect(controller.get('tagged')).to.equal(undefined);
+      expect(controller.get('tagged')).to.equal(null);
     });
   });
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
 
-export default Ember.ObjectController.extend({
+export default Ember.Controller.extend({
 
 });

--- a/tests/dummy/app/controllers/blockless-multiple.js
+++ b/tests/dummy/app/controllers/blockless-multiple.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Folks from 'dummy/mixins/folks';
 
-export default Ember.ObjectController.extend(Folks, {
+export default Ember.Controller.extend(Folks, {
   isDisabled: false,
   actions: {
     tagYouAreIt: function(object) {

--- a/tests/dummy/app/controllers/blockless-single.js
+++ b/tests/dummy/app/controllers/blockless-single.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Folks from 'dummy/mixins/folks';
 
-export default Ember.ObjectController.extend(Folks, {
+export default Ember.Controller.extend(Folks, {
   isDisabled: false,
   actions: {
     tagYouAreIt: function(object) {

--- a/tests/dummy/app/controllers/multiple.js
+++ b/tests/dummy/app/controllers/multiple.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Folks from 'dummy/mixins/folks';
 
-export default Ember.ObjectController.extend(Folks, {
+export default Ember.Controller.extend(Folks, {
   actions: {
     selectionsChanged: function(selections) {
       this.set('currentSelections', selections);

--- a/tests/dummy/app/controllers/single.js
+++ b/tests/dummy/app/controllers/single.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Folks from 'dummy/mixins/folks';
 
-export default Ember.ObjectController.extend(Folks, {
+export default Ember.Controller.extend(Folks, {
   isDisabled: false,
   isRequired: false,
   hasAutofocus: false,

--- a/tests/dummy/app/templates/blockless-multiple.hbs
+++ b/tests/dummy/app/templates/blockless-multiple.hbs
@@ -7,7 +7,7 @@
 </p>
 <p>Selected:</p>
 <ul>
-{{#each selection in model}}
+{{#each model as |selection|}}
   <li>{{selection.name}}</li>
 {{else}}
   <li>(None)</li>
@@ -15,7 +15,7 @@
 </ul>
 <p>All options:</p>
 <ul>
-{{#each folk in folks}}
+{{#each folks as |folk|}}
   <li>{{folk.name}} - <a href="#" {{action "removeFolk" folk}}>Remove Folk</a></li>
 {{else}}
   <li>(None)</li>

--- a/tests/dummy/app/templates/blockless-single.hbs
+++ b/tests/dummy/app/templates/blockless-single.hbs
@@ -8,7 +8,7 @@
 <p>Selected: {{it.name}}</p>
 <p>All options:</p>
 <ul>
-{{#each folk in folks}}
+{{#each folks as |folk|}}
   <li>{{folk.name}} - <a href="#" {{action "removeFolk" folk}}>Remove Folk</a></li>
 {{else}}
   <li>(None)</li>

--- a/tests/dummy/app/templates/multiple.hbs
+++ b/tests/dummy/app/templates/multiple.hbs
@@ -8,7 +8,7 @@
 </p>
 <p>Selected:</p>
 <ul>
-{{#each selection in model}}
+{{#each model as |selection|}}
   <li>{{selection.name}}</li>
 {{else}}
   <li>(None)</li>

--- a/tests/helpers/get-component-by-id.js
+++ b/tests/helpers/get-component-by-id.js
@@ -1,0 +1,11 @@
+import Ember from "ember";
+
+function getComponentById(app, id) {
+  return app.__container__.lookup('-view-registry:main')[id];
+}
+
+const customHelpers = (function() {
+  Ember.Test.registerHelper('getComponentById', getComponentById);
+})();
+
+export default customHelpers;

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import Application from '../../app';
 import Router from '../../router';
 import config from '../../config/environment';
+import getComponentById from './get-component-by-id';
 
 export default function startApp(attrs) {
   var application;


### PR DESCRIPTION
This still doesn't have all the tests passing.

 1. test against Ember 1.13.2
 1. change `{{#each foo in foos}}` to `{{#each foos as |foo|}}`
 1. introduce `getComponentById` helper that uses `app.__container__.lookup('-view-registry:main')` since Ember no longer exposes `Ember.View.views`
 1. don't call `set` in `didInsertElemenent` because that can cause performance problems in Glimmer; instead, defer the `set` to the `afterRender` queue
 1. eliminate use of `Ember.ObjectController` in tests
 1. use the `change` handler that `Ember.Component`s come with instead of adding a handler in `didInsertElement` via `this.$.on('change')`
 1. remove observer on `content.@each` that was writing changes back upstream and sending actions. In Glimmer, the component will get rerendered automatically from upstream changes; it only needs to notify when the source of the change is a DOM event within its element
 1. when no item is selected, set `value` and `selection` to `null`, not `undefined`; the latter has problems with properties that use `alias`
 1. upgrade ember-cli-app-version to remove some warnings
 1. warn if the user passes `form` since Glimmer doesn't support that at the moment. See emberjs/ember.js#11221