### PR TITLE
use a null default tabindex so that the select is tabbable in a form...

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -51,7 +51,7 @@ export default Ember.Component.extend({
    * @type Integer
    * @ default 1
    */
-  tabindex: 1,
+  tabindex: null,
 
   /**
    * Auxiliary computed property that replaces `content.`

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -49,9 +49,9 @@ export default Ember.Component.extend({
    *
    * @property tabindex
    * @type Integer
-   * @ default 1
+   * @ default 0
    */
-  tabindex: null,
+  tabindex: 0,
 
   /**
    * Auxiliary computed property that replaces `content.`

--- a/tests/acceptance/x-select-single-test.js
+++ b/tests/acceptance/x-select-single-test.js
@@ -86,13 +86,13 @@ describe('XSelect: Single Selection', function() {
 
   describe('tabindex', function() {
     it('has no tabindex by default', function() {
-      expect(this.$().attr('tabindex')).to.be.not.ok();
+      expect(this.$().attr('tabindex')).to.equal('0');
     });
 
     it('uses a passed-in tabindex if one is given', function() {
       Ember.run(function() {
         component.set('tabindex', 2);
-      }.bind(this));
+      });
       expect(this.$().attr('tabindex')).to.equal('2');
     });
   });

--- a/tests/acceptance/x-select-single-test.js
+++ b/tests/acceptance/x-select-single-test.js
@@ -84,6 +84,19 @@ describe('XSelect: Single Selection', function() {
     });
   });
 
+  describe('tabindex', function() {
+    it('has no tabindex by default', function() {
+      expect(this.$().attr('tabindex')).to.be.not.ok();
+    });
+
+    it('uses a passed-in tabindex if one is given', function() {
+      Ember.run(function() {
+        component.set('tabindex', 2);
+      }.bind(this));
+      expect(this.$().attr('tabindex')).to.equal('2');
+    });
+  });
+
   shouldBindAttrs();
 
 });


### PR DESCRIPTION
…the way you'd expect it to be.

The previous behavior was that `select`s were given a default `tabindex` of 1, which made tabbing through a form not work the way you'd expect. Let me know if you have any questions and thank you for a handy component! 

(as a workaround, you can pass `tabindex=null` to the component, this just makes that the default)