### PR TITLE
Switch to yield the select to the block

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ and binding aware. It is used in conjuction with the `x-option`
 component to construct select boxes. E.g.
 
 ```handlebars
-{{#x-select value=bob action="selectPerson"}}
-  {{#x-option value=fred}}Fred Flintstone{{/x-option}}
-  {{#x-option value=bob}}Bob Newhart{{/x-option}}
+{{#x-select value=bob action="selectPerson" as |select|}}
+  {{#x-option value=fred select=select}}Fred Flintstone{{/x-option}}
+  {{#x-option value=bob select=select}}Bob Newhart{{/x-option}}
 {{/x-select}}
 ```
 
@@ -40,10 +40,10 @@ option. This means you can pass an array as its value, and it will set
 its selections directly on that array.
 
 ```handlebars
-{{#x-select value=selections multiple=true action="selectionsChanged"}}
- {{#x-option value=fred}}Fred Flintstone{{/x-option}}
- {{#x-option value=bob}}Bob Newhart{{/x-option}}
- {{#x-option value=andrew}}Andrew WK{{/x-option}}
+{{#x-select value=selections multiple=true action="selectionsChanged" as |select|}}
+ {{#x-option value=fred select=select}}Fred Flintstone{{/x-option}}
+ {{#x-option value=bob select=select}}Bob Newhart{{/x-option}}
+ {{#x-option value=andrew select=select}}Andrew WK{{/x-option}}
 {{/x-select}}
 ```
 
@@ -134,9 +134,9 @@ cases, you can associate arbitrary attributes with the component
 itself and use them later inside your action handler.  For example:
 
 ```handlebars
-{{#x-select action="didMakeSelection" default=anything}}
+{{#x-select action="didMakeSelection" default=anything as |select|}}
   <option>Nothing</option>
-  {{#x-option value=something}}Something{{/x-option}}
+  {{#x-option value=something select=select}}Something{{/x-option}}
 {{/x-select}}
 ```
 then, inside your action handler:

--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -28,6 +28,15 @@ export default Ember.Component.extend({
   value: null,
 
   /**
+   * The value of the parent `x-select`
+   *
+   * @property x-select
+   * @type XSelectComponent
+   * @default null
+   */
+  select: null,
+
+  /**
    * Property bound to the `selected` attribute of the native
    * `<option>` element. It is aware of the containing `x-select`'s
    * value and will mark itself if it is the same.
@@ -55,9 +64,9 @@ export default Ember.Component.extend({
     this._super.apply(this, arguments);
 
     Ember.run.scheduleOnce('afterRender', () => {
-      var select = this.nearestOfType(XSelectComponent);
+      /* Use an assigned select, or search for one nearby */
+      var select = this.get('select') || this.nearestOfType(XSelectComponent);
       Ember.assert("x-option component declared without enclosing x-select", !!select);
-      this.set('select', select);
       select.registerOption(this);
     });
   },

--- a/app/templates/components/x-select.hbs
+++ b/app/templates/components/x-select.hbs
@@ -1,10 +1,10 @@
 {{#if hasBlock}}
-  {{yield}}
+  {{yield this}}
 {{else}}
   {{#if placeholder}}
     <option>{{placeholder}}</option>
   {{/if}}
   {{#each _optionValues as |option|}}
-    {{#x-option value=option.value}}{{option.label}}{{/x-option}}
+    {{#x-option value=option.value select=this}}{{option.label}}{{/x-option}}
   {{/each}}
 {{/if}}

--- a/tests/dummy/app/templates/multiple.hbs
+++ b/tests/dummy/app/templates/multiple.hbs
@@ -1,9 +1,9 @@
 <p>
 {{#x-select value=selections action="selectionsChanged" disabled=isDisabled multiple=true title=title required=isRequired
-    autofocus=hasAutofocus name=attrName form=attrForm size=attrSize}}
-  {{#x-option value=charles}}Charles{{/x-option}}
-  {{#x-option value=bastion}}Bastion{{/x-option}}
-  {{#x-option value=stanley}}Stanley{{/x-option}}
+    autofocus=hasAutofocus name=attrName form=attrForm size=attrSize as |select|}}
+  {{#x-option value=charles select=select}}Charles{{/x-option}}
+  {{#x-option value=bastion select=select}}Bastion{{/x-option}}
+  {{#x-option value=stanley select=select}}Stanley{{/x-option}}
   <option>Nobody</option>
 {{/x-select}}
 </p>

--- a/tests/dummy/app/templates/single.hbs
+++ b/tests/dummy/app/templates/single.hbs
@@ -1,9 +1,9 @@
 <p>
 {{#x-select value=it action="tagYouAreIt" disabled=isDisabled title=title required=isRequired
-    autofocus=hasAutofocus name=attrName form=attrForm size=attrSize}}
-  {{#x-option value=charles}}Charles{{/x-option}}
-  {{#x-option value=bastion}}Bastion{{/x-option}}
-  {{#x-option value=stanley}}Stanley{{/x-option}}
+    autofocus=hasAutofocus name=attrName form=attrForm size=attrSize as |select|}}
+  {{#x-option value=charles select=select}}Charles{{/x-option}}
+  {{#x-option value=bastion select=select}}Bastion{{/x-option}}
+  {{#x-option value=stanley select=select}}Stanley{{/x-option}}
   <option>Nobody</option>
 {{/x-select}}
 </p>


### PR DESCRIPTION
* accept select on x-option
* use select on x-option when register
* fallback to nearestNeighbor for non-ember-2 beta
* yield select to the block in handlebars
* pass the select for blockless version