### PR TITLE
bump ember dependency for parentView bugfix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-beta
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "emberx-select",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.13.2",
+    "ember": "1.13.4",
     "ember-resolver": "~0.1.15",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/tests/acceptance/x-select-zany-embedded-html-test.js
+++ b/tests/acceptance/x-select-zany-embedded-html-test.js
@@ -1,0 +1,33 @@
+/*global expect */
+/* jshint expr:true */
+
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { it } from 'ember-mocha';
+import { beforeEach, afterEach, describe } from '../test-helper';
+
+
+var App;
+
+describe('XSelect: Embedded HTML', function() {
+  beforeEach(function() {
+    App = startApp();
+    visit("/zany-embedded-html");
+  });
+  beforeEach(function() {
+    var el = Ember.$('select');
+    this.component = getComponentById(el.attr('id'));
+    this.$ = function() {
+      return this.component.$.apply(this.component, arguments);
+    };
+    this.controller = App.__container__.lookup('controller:zanyEmbeddedHTML');
+  });
+
+  it("renders", function() {
+    expect(this.$()).to.exist;
+  });
+
+  afterEach(function() {
+    Ember.run(App, 'destroy');
+  });
+});

--- a/tests/dummy/app/controllers/zany-embedded-html.js
+++ b/tests/dummy/app/controllers/zany-embedded-html.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+/**
+ * This controller sets up things a bit weirdly, because we're trying
+ * to trigger this bug in ember:
+ * https://github.com/emberjs/ember.js/pull/11266/files
+ *
+ * After initialization, it atumotically triggers a re-render by
+ * updating the groups to be rendered. This will fail on ember
+ * 1.13.{0,3}.
+ *
+ * It was initially reported as:
+ *
+ * https://github.com/thefrontside/emberx-select/issues/44
+ */
+
+export default Ember.Controller.extend({
+  groupsOfZanyThings: [],
+
+
+  schedulePopulate: Ember.on('init', function() {
+    Ember.run.schedule('afterRender', this, 'populate');
+  }),
+
+  populate: function() {
+    this.set('groupsOfZanyThings', Ember.A([
+      {
+        label: 'Sandwiches',
+        things: [
+          { description: 'Cucumber and Peanutbutter' },
+          { description: 'Wasabe Muffuletta'},
+          { description: 'Ice Cream Burger' }
+        ]
+      }, {
+        label: 'Haircuts',
+        things: [
+          { description: 'One Direction' },
+          { description: 'Inverse Beehive' },
+          { description: '"The Cellist"' }
+        ]
+      }, {
+        label: 'Cars',
+        things: [
+          { description: 'The Smart Car' },
+          { description: 'The Dumb Car' },
+          { description: 'Delorean on Fire' }
+        ]
+      }
+    ]));
+  }
+});

--- a/tests/dummy/app/controllers/zany-embedded-html.js
+++ b/tests/dummy/app/controllers/zany-embedded-html.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
  * to trigger this bug in ember:
  * https://github.com/emberjs/ember.js/pull/11266/files
  *
- * After initialization, it atumotically triggers a re-render by
+ * After initialization, it automatically triggers a re-render by
  * updating the groups to be rendered. This will fail on ember
  * 1.13.{0,3}.
  *

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('blockless-single');
   this.route('blockless-single-option-value');
   this.route('blockless-multiple');
+  this.route('zany-embedded-html');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,6 @@
 <h1> XSelect </h1>
 
-{{#link-to 'single'}}Single{{/link-to}} | {{#link-to 'multiple'}}Multiple{{/link-to}} | {{#link-to 'blockless-single'}}Blockless Single{{/link-to}} | {{#link-to 'blockless-single-option-value'}}Blockless Single W/ Option Value{{/link-to}} | {{#link-to 'blockless-multiple'}}Blockless Multiple{{/link-to}}
+{{#link-to 'single'}}Single{{/link-to}} | {{#link-to 'multiple'}}Multiple{{/link-to}} | {{#link-to 'blockless-single'}}Blockless Single{{/link-to}} | {{#link-to 'blockless-single-option-value'}}Blockless Single W/ Option Value{{/link-to}} | {{#link-to 'blockless-multiple'}}Blockless Multiple{{/link-to}} | {{#link-to 'zany-embedded-html'}} Embedded HTML{{/link-to}}
 
 <div>
   {{outlet}}

--- a/tests/dummy/app/templates/zany-embedded-html.hbs
+++ b/tests/dummy/app/templates/zany-embedded-html.hbs
@@ -1,0 +1,16 @@
+<p>
+  Anything that is valid within a <code>&lt;select&gt;</code> is also valid within <code>&lt;x-select&gt;</code>:
+  <button {{action "populate"}}>Populate</button>
+</p>
+<p>
+  {{#x-select value=thing}}
+    <option>Choose one of the following zaney options! ...</option>
+    {{#each groupsOfZanyThings as |group|}}
+      <optgroup label={{group.label}}>
+        {{#each group.things as |thing|}}
+          {{#x-option value=thing}}{{thing.description}}{{/x-option}}
+        {{/each}}
+      </optgroup>
+    {{/each}}
+  {{/x-select}}
+</p>


### PR DESCRIPTION
In order to fetch the parentView for an element reliably, we depend on a
bugfix that only came available in Ember v1.13.4

https://github.com/emberjs/ember.js/pull/11266

This also adds a test case that was breaking in 1.13.{0-3}

resolves #44