### PR TITLE
Use `didRender` in `x-option`

### DIFF
--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -51,15 +51,11 @@ export default Ember.Component.extend({
    *
    * @override
    */
-  didInsertElement: function() {
-    this._super.apply(this, arguments);
-
-    Ember.run.scheduleOnce('afterRender', () => {
-      var select = this.nearestOfType(XSelectComponent);
-      Ember.assert("x-option component declared without enclosing x-select", !!select);
-      this.set('select', select);
-      select.registerOption(this);
-    });
+  didRender() {
+    var select = this.nearestOfType(XSelectComponent);
+    Ember.assert("x-option component declared without enclosing x-select", !!select);
+    this.set('select', select);
+    select.registerOption(this);
   },
 
   /**


### PR DESCRIPTION
According to the [ember 1.13.0][ember] release notes, `didRender` will
be called after the element is inserted.

This makes manually scheduling code to the `afterRender` queue obsolete.

```
DEPRECATION: A property of <my-app@view:-outlet::ember547> was modified
inside the `didInsertElement` hook. You should never change properties
on components, services or models during `didInsertElement` because
it causes significant performance degradation.
```

[ember]: http://emberjs.com/blog/2015/06/12/ember-1-13-0-released.html