### PR TITLE
Make array values immuatable

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -125,15 +125,7 @@ export default Ember.Component.extend({
       return option.$().is(':selected');
     });
 
-    Ember.A(options);
-
-    var newValues = options.mapBy('value');
-
-    if (isArray(this.get('value'))) {
-      this.get('value').setObjects(newValues);
-    } else {
-      this.set('value', newValues);
-    }
+    this.set('value', Ember.A(options).mapBy('value'));
   },
 
   /**


### PR DESCRIPTION
It used to be with multiselects you would edit the value array in place
as you intereacted with the select component. This caused problems
especially when have collections such as async ember data
relationships.

Now we always create a new array for every single selection.