### PR TITLE
Remove depercation caused changing data in didRender

### DIFF
--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -52,6 +52,10 @@ export default Ember.Component.extend({
    * @override
    */
   didRender() {
+    Ember.run.scheduleOnce('afterRender', this, 'registerWithXSelect');
+  },
+
+  registerWithXSelect() {
     var select = this.nearestOfType(XSelectComponent);
     Ember.assert("x-option component declared without enclosing x-select", !!select);
     this.set('select', select);


### PR DESCRIPTION
This fixes #66. I ended up having to move the way we register x-option
with it's parent component into an ember after render run loop.