### PR TITLE
Schedule x-option registration in didInsertElement() hook instead of didRender()

### DIFF
--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -52,7 +52,7 @@ export default Ember.Component.extend({
    * @override
    */
   didInsertElement() {
-    this._super();
+    this._super(this, arguments);
     Ember.run.scheduleOnce('afterRender', this, 'registerWithXSelect');
   },
 

--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -51,7 +51,8 @@ export default Ember.Component.extend({
    *
    * @override
    */
-  didRender() {
+  didInsertElement() {
+    this._super();
     Ember.run.scheduleOnce('afterRender', this, 'registerWithXSelect');
   },
 


### PR DESCRIPTION
Just a simple hook rename didRender() -> didInsertElement()
See #70 