### PR TITLE
Fix issue with unregisterOption

### DIFF
--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -70,6 +70,9 @@ export default Ember.Component.extend({
    */
   willDestroyElement: function() {
     this._super.apply(this, arguments);
-    this.get('select').unregisterOption(this);
+    var select = this.get('select');
+    if (select) {
+      select.unregisterOption(this);
+    }
   }
 });


### PR DESCRIPTION
Had an issue where if the model for the options changed, it was firing back an error saying `cannot call method unregisterOption of undefined`. So now I am checking for it prior to calling `unregisterOption`.