### PR TITLE
Fixes demo for multiple

### DIFF
--- a/tests/dummy/app/controllers/multiple.js
+++ b/tests/dummy/app/controllers/multiple.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import Folks from 'dummy/mixins/folks';
 
 export default Ember.Controller.extend(Folks, {
+  currentSelections: Ember.computed.reads('selections'),
   actions: {
     selectionsChanged: function(selections) {
       this.set('currentSelections', selections);

--- a/tests/dummy/app/templates/multiple.hbs
+++ b/tests/dummy/app/templates/multiple.hbs
@@ -9,7 +9,7 @@
 </p>
 <p>Selected:</p>
 <ul>
-{{#each model as |selection|}}
+{{#each currentSelections as |selection|}}
   <li>{{selection.name}}</li>
 {{else}}
   <li>(None)</li>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'dummy',
     environment: environment,
     baseURL: '/',
-    locationType: 'auto',
+    locationType: 'hash',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
The demo was relying on two way data binding to update its values. Now we
use the propery is being set by the action.

Also switched to `hash` location so the gh-pages demo works correctly.