### PR TITLE
Remove dead properties leftover from x-select-blockless

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -24,8 +24,6 @@ var isArray = Ember.isArray;
 export default Ember.Component.extend({
   tagName: "select",
   classNameBindings: [":x-select"],
-  //FIXME: add 'form' attribute binding back in when https://github.com/tildeio/htmlbars/pull/353#issuecomment-116187095
-  //is merged.
   attributeBindings: ['disabled', 'tabindex', 'multiple', 'form', 'name', 'autofocus', 'required', 'size', 'title'],
 
   /**
@@ -54,22 +52,6 @@ export default Ember.Component.extend({
    * @ default 0
    */
   tabindex: 0,
-
-  /**
-   * Alias to `value`.
-   * This way we accept `value` or `selection` properties.
-   *
-   * @property selection
-   */
-  selection: Ember.computed.alias('value'),
-
-  /**
-   * Alias to `prompt`.
-   * This way we accept `prompt` or `placeholder` properties.
-   *
-   * @property placeholder
-   */
-  placeholder: Ember.computed.alias('prompt'),
 
   /**
    * The collection of options for this select box. When options are

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "ember": "1.13.7",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-mocha": "0.8.1",
+    "ember-mocha": "0.8.8",
     "chai-jquery": "~2.0.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-resolver": "~0.1.18",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "chai-jquery": "~2.0.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-mocha": "0.8.0",
+    "ember-cli-mocha": "0.9.8",
     "ember-cli-release": "0.2.5",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.0.0",

--- a/tests/acceptance/shared/attr-test.js
+++ b/tests/acceptance/shared/attr-test.js
@@ -1,5 +1,4 @@
 /*global expect */
-/*global it */
 import { beforeEach, describe } from '../../test-helper';
 import { it } from 'ember-mocha';
 


### PR DESCRIPTION
This is to remove the leftover properties in x-select that were there
for x-select-blockless. We've since moved blockless to its own repo.

I also did a little clean up and fixed a jshint test. 