### PR TITLE
Update register code to set default option

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -111,6 +111,22 @@ export default Ember.Component.extend({
   },
 
   /**
+   * If no explicit value is set, apply default values based on selected=true in
+   * the template.
+   *
+   * @private
+   */
+  _setDefaultValues: function() {
+    if( !this.get('value')){
+      if (this.get('multiple')) {
+        this._updateValueMultiple();
+      } else {
+        this._updateValueSingle();
+      }
+    }
+  },
+
+  /**
    * @override
    */
   willDestroyElement: function() {
@@ -139,6 +155,7 @@ export default Ember.Component.extend({
    */
   registerOption: function(option) {
     this.get('options').addObject(option);
+    this._setDefaultValues();
   },
 
   /**
@@ -146,5 +163,6 @@ export default Ember.Component.extend({
    */
   unregisterOption: function(option) {
     this.get('options').removeObject(option);
+    this._updateValueSingle();
   }
 });

--- a/tests/acceptance/default-values-test.js
+++ b/tests/acceptance/default-values-test.js
@@ -1,0 +1,83 @@
+/* jshint expr:true */
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach
+} from 'mocha';
+import { expect } from 'chai';
+import startApp from '../helpers/start-app';
+import Ember from 'ember';
+
+describe('XSelect: Default Values', function() {
+  let application;
+
+  beforeEach(function() {
+    application = startApp();
+  });
+
+  afterEach(function() {
+    Ember.run(application, 'destroy');
+  });
+
+  describe('Initializing with default values', function(){
+    beforeEach(function() {
+      visit('/default-value');
+    });
+
+    it('initializes with defaults if no explicit value is present', function() {
+      expect($(".spec-selected-make:contains('Selected Make: Honda')")).to.exist;
+    });
+
+    it('sets the selected property on the correct default option', function() {
+      expect($(".spec-car-make option:contains('Honda')")).to.be.selected;
+    });
+
+    it('can set a default to the first option in a dynamic list', function() {
+      expect($(".spec-selected-model:contains('Selected Model: Fit')")).to.exist;
+    });
+
+    it('sets the selected property on the correct default option', function() {
+      expect($(".spec-car-model option:contains('Fit')")).to.be.selected;
+    });
+
+    it('initializes with the correct explicit value if one is present', function() {
+      expect($(".spec-selected-make-from-model:contains('Selected Make: Ford')")).to.exist;
+    });
+
+    it('sets the selected property on the correct explicity value option', function() {
+      expect($(".spec-autopopulated-make-field option:contains('Ford')")).to.be.selected;
+    });
+
+    it('does not set the selected property on the default option', function() {
+      expect($(".spec-autopopulated-make-field option:contains('Toyota')")).not.to.be.selected;
+    });
+
+
+    describe("Changing the value on fields with default values", function() {
+      beforeEach(function() {
+        select('.spec-car-make', 'Toyota');
+      });
+
+      it("updates the value", function() {
+        expect($(".spec-selected-make:contains('Selected Make: Toyota')")).to.exist;
+      });
+
+      it("sets the selected property on the correct updated option", function() {
+        expect($(".spec-car-make option:contains('Toyota')")).to.be.selected;
+      });
+
+      it("removes the selected property on the previously selected option", function() {
+        expect($(".spec-car-make option:contains('Honda')")).not.to.be.selected;
+      });
+
+      it("reevalutates the dynamic default value", function() {
+        expect($(".spec-selected-model:contains('Selected Model: Camry')")).to.exist;
+      });
+
+      it("sets the selected property on the correct default value", function() {
+        expect($(".spec-car-model option:contains('Camry')")).to.be.selected;
+      });
+    });
+  });
+});

--- a/tests/acceptance/x-select-multiple-test.js
+++ b/tests/acceptance/x-select-multiple-test.js
@@ -80,7 +80,6 @@ describe('XSelect: Multiple Selection', function() {
       expect(this.exception).not.to.be.undefined;
       expect(this.exception.message).to.match(/enumerable/);
     });
-
   });
 
   shouldBindAttrs();

--- a/tests/dummy/app/controllers/default-value.js
+++ b/tests/dummy/app/controllers/default-value.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import Cars from 'dummy/mixins/cars';
+
+export default Ember.Controller.extend(Cars, {
+  autopopulatedField: null,
+
+  make: null,
+
+  carModel: null,
+
+  trim: null,
+
+  makeIsSet: false,
+
+  modelIsSet: false,
+
+  trimIsSet: false,
+
+  actions: {
+    setMake: function(object) {
+      if (object) {
+        console.log('You selected Make:', object.name);
+      }
+    },
+    setCarModel: function(object) {
+      if (object) {
+        console.log('You selected Model:', object.name);
+      }
+    },
+    setTrim: function(object) {
+      if (object) {
+        console.log('You selected Trim:', object.name);
+      }
+    },
+    updateField: function(object) {
+      if (object) {
+        console.log('You selected Make:', object.name);
+      }
+    }
+  }
+});

--- a/tests/dummy/app/mixins/cars.js
+++ b/tests/dummy/app/mixins/cars.js
@@ -1,0 +1,47 @@
+import Ember from 'ember';
+
+export var sport = {name: 'Sport'};
+
+export var sedan = {name: 'Sedan'};
+
+export var hatchback = {name: 'Hatchback'};
+
+export var camry = {name: 'Camry', trimOptions: [sport, sedan, hatchback]};
+
+export var corolla = {name: 'Corolla', trimOptions: [sedan]};
+
+export var tacoma = {name: 'Tacoma', trimOptions: []};
+
+export var fit = {name: 'Fit', trimOptions: [sport, hatchback]};
+
+export var civic = {name: 'Civic', trimOptions: [sedan, sport]};
+
+export var accord = {name: 'Accord', trimOptions: []};
+
+export var focus = {name: 'Focus', trimOptions: [sport, hatchback]};
+
+export var fiesta = {name: 'Fiesta', trimOptions: [hatchback, sedan]};
+
+export var mustang = {name: 'Mustang', trimOptions: [sport]};
+
+export var toyotaModels = [camry, corolla, tacoma];
+
+export var hondaModels = [fit, civic, accord];
+
+export var fordModels = [focus, fiesta, mustang];
+
+export var toyota = {name: 'Toyota', models: toyotaModels};
+
+export var honda = {name: 'Honda', models: hondaModels};
+
+export var ford = {name: 'Ford', models: fordModels};
+
+export default Ember.Mixin.create({
+  makes: [toyota, honda, ford],
+
+  toyota: toyota,
+
+  honda: honda,
+
+  ford: ford
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ Router.map(function() {
   this.route('single');
   this.route('multiple');
   this.route('zany-embedded-html');
+  this.route('default-value');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/default-value.js
+++ b/tests/dummy/app/routes/default-value.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import Cars from 'dummy/mixins/cars';
+
+export default Ember.Route.extend(Cars, {
+  model: function() {
+    return this.get('makes')[2];
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,6 @@
 <h1> XSelect </h1>
 
-{{#link-to 'single'}}Single{{/link-to}} | {{#link-to 'multiple'}}Multiple{{/link-to}} | {{#link-to 'zany-embedded-html'}} Embedded HTML{{/link-to}}
+{{#link-to 'single'}}Single{{/link-to}} | {{#link-to 'multiple'}}Multiple{{/link-to}} | {{#link-to 'zany-embedded-html'}} Embedded HTML{{/link-to}} | {{#link-to 'default-value'}}With Defaults{{/link-to}}
 
 <div>
   {{outlet}}

--- a/tests/dummy/app/templates/default-value.hbs
+++ b/tests/dummy/app/templates/default-value.hbs
@@ -1,0 +1,65 @@
+<p>This example shows how you can set default values for your selections by setting the selected=true property on an option and how these defaults are impacted by changes to the dynamic content in your list of options.</p>
+<hr>
+<h2>Select a Car Make</h2>
+<p>Default set to option two (Honda)</p>
+<p>
+  {{#x-select value=(mut make) action=(action "setMake") class="spec-car-make"}}
+    {{#x-option value=ford}}Ford{{/x-option}}
+    {{#x-option value=honda selected=true}}Honda{{/x-option}}
+    {{#x-option value=toyota}}Toyota{{/x-option}}
+    <option>Not Selected</option>
+  {{/x-select}}
+</p>
+<p class="spec-selected-make">Selected Make: {{make.name}}</p>
+<hr>
+
+<h2>Select a Car Model</h2>
+<p>Default set to the first option in the dynamic list</p>
+<p>
+  {{#x-select value=(mut carModel) action=(action "setCarModel") class="spec-car-model"}}
+    {{#each make.models as |carModel index|}}
+      {{#if index}}
+        {{#x-option value=carModel}}{{carModel.name}}{{/x-option}}
+      {{else}}
+        {{#x-option value=carModel selected=true}}{{carModel.name}}{{/x-option}}
+      {{/if}}
+    {{/each}}
+    <option>Not Selected</option>
+  {{/x-select}}
+</p>
+<p class="spec-selected-model">Selected Model: {{carModel.name}}</p>
+<hr>
+
+<h2>Select a Car Trim Option</h2>
+<p>Default set to the first option in the dynamic list</p>
+<p>
+  {{#x-select value=(mut trim) action=(action "setTrim") class="spec-car-trim"}}
+    {{#each carModel.trimOptions as |trim index|}}
+      {{#if index}}
+        {{#x-option value=trim}}{{trim.name}}{{/x-option}}
+      {{else}}
+        {{#x-option value=trim selected=true}}{{trim.name}}{{/x-option}}
+      {{/if}}
+    {{/each}}
+    <option>Not Selected</option>
+  {{/x-select}}
+</p>
+<p class="spec-selected-trim">Selected Trim: {{trim.name}}</p>
+<hr>
+
+<p>An explicit value overrides any defaults.</p>
+<p>Here, the model (initialized as Ford) is overriding the default to select the first option in the list (Toyota).</p>
+<p>
+  {{#x-select value=(mut model) action=(action "updateField") class="spec-autopopulated-make-field"}}
+    {{#each makes as |make index|}}
+      {{#if index}}
+        {{#x-option value=make}}{{make.name}}{{/x-option}}
+      {{else}}
+        {{! Would default to the first option if model is not set}}
+        {{#x-option value=make selected=true}}{{make.name}}{{/x-option}}
+      {{/if}}
+    {{/each}}
+    <option>Not Selected</option>
+  {{/x-select}}
+</p>
+<p class="spec-selected-make-from-model">Selected Make: {{model.name}}</p>


### PR DESCRIPTION
Provides support for #81 by allowing the implementer to specify `selected=true` property on an x-option component to set a default value for the selection. 

Implementers can use this update to default to the first item in a dynamic list by taking advantage of the index block param for the each helper.  This solution is provided as a compromise to allow implementers to opt in to default selection behavior. Further improvements may be made at a later date.

```
{{#x-select value=(mut make) action=(action "setMake") class="spec-car-make"}}
  {{#x-option value=ford}}Ford{{/x-option}}
  {{#x-option value=honda selected=true}}Honda{{/x-option}}
  {{#x-option value=toyota}}Toyota{{/x-option}}
  <option>Not Selected</option>
{{/x-select}}
```

Will default to option two (Honda) if no explicit value for ```make``` is present.

```
{{#x-select value=(mut carModel) action=(action "setCarModel") class="spec-car-model"}}
    {{#each make.models as |carModel index|}}
      {{#if index}}
        {{#x-option value=carModel}}{{carModel.name}}{{/x-option}}
      {{else}}
        {{#x-option value=carModel selected=true}}{{carModel.name}}{{/x-option}}
      {{/if}}
    {{/each}}
    <option>Not Selected</option>
  {{/x-select}}
```

Will default to the first option in the dynamic ```make.models``` list if no explicit value is set for ```carModel``` and will reevaluate the appropriate default if the content of the list changes.

