### PR TITLE
Intialize defaults to `null` rather than false

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -33,7 +33,7 @@ export default Ember.Component.extend({
    * @type Boolean
    * @default false
    */
-  disabled: false,
+  disabled: null,
 
   /**
    * Bound to the `multiple` attribute on the native <select> tag.
@@ -42,7 +42,7 @@ export default Ember.Component.extend({
    * @type Boolean
    * @default false
    */
-  multiple: false,
+  multiple: null,
 
   /**
    * Bound to the `tabindex` attribute on the native <select> tag.


### PR DESCRIPTION
If you have attributes like `multiple` or `disabled` set on a `<select>`
at all it will think it's true. Even if you set `disabled="false"` it
will still disable selects.

By intializing the defaults to null it won't apply the attribute to the select