### PR TITLE
check state before updating value

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -139,6 +139,10 @@ export default Ember.Component.extend({
    * @utility
    */
   _updateValue: function() {
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+    
     if (this.get('multiple')) {
       this._updateValueMultiple();
     } else {


### PR DESCRIPTION
Don't update the values if the component is being destroyed or is destroyed. This cropped up as a problem when the x-select was inside a liquid-if.