### PR TITLE
Fix bug where falsy initial values were changed to null

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -153,7 +153,7 @@ export default Ember.Component.extend({
    * @private
    */
   _setDefaultValues: function() {
-    if (!this.get('value')) {
+    if (this.get('value') == null) {
       this._updateValue();
     }
   },

--- a/tests/acceptance/default-values-test.js
+++ b/tests/acceptance/default-values-test.js
@@ -53,6 +53,13 @@ describe('XSelect: Default Values', function() {
       expect($(".spec-autopopulated-make-field option:contains('Toyota')")).not.to.be.selected;
     });
 
+    it('sets the selected property to the explicitly set value', function() {
+      expect($(".spec-autopopulated-quantity-field option:contains('0')")).to.be.selected;
+    });
+
+    it('initializes with the correct explicit value if one is present even if that value is falsy', function() {
+      expect($(".spec-selected-quantity:contains('Selected Quantity: 0')")).to.exist;
+    });
 
     describe("Changing the value on fields with default values", function() {
       beforeEach(function() {

--- a/tests/dummy/app/controllers/default-value.js
+++ b/tests/dummy/app/controllers/default-value.js
@@ -10,11 +10,15 @@ export default Ember.Controller.extend(Cars, {
 
   trim: null,
 
+  selectedQuantity: 0,
+
   makeIsSet: false,
 
   modelIsSet: false,
 
   trimIsSet: false,
+
+  quantities: [5, 4, 3, 2, 1, 0],
 
   actions: {
     setMake: function(object) {
@@ -35,6 +39,11 @@ export default Ember.Controller.extend(Cars, {
     updateField: function(object) {
       if (object) {
         console.log('You selected Make:', object.name);
+      }
+    },
+    updateSelectedQuantity: function(object) {
+      if (object != null) {
+        console.log('You selected Quantity:', object);
       }
     }
   }

--- a/tests/dummy/app/templates/default-value.hbs
+++ b/tests/dummy/app/templates/default-value.hbs
@@ -63,3 +63,20 @@
   {{/x-select}}
 </p>
 <p class="spec-selected-make-from-model">Selected Make: {{model.name}}</p>
+
+<p>An explicit value overrides any defaults.</p>
+<p>Here, the selectedQuantity (initially 0) is overriding the default to select the first option in the list (5).</p>
+<p>
+  {{#x-select value=(mut selectedQuantity) action=(action "updateSelectedQuantity") class="spec-autopopulated-quantity-field"}}
+    {{#each quantities as |quantity index|}}
+      {{#if index}}
+        {{#x-option value=quantity}}{{quantity}}{{/x-option}}
+      {{else}}
+      {{! Would default to the first option if quantity is not set}}
+        {{#x-option value=quantity selected=true}}{{quantity}}{{/x-option}}
+      {{/if}}
+    {{/each}}
+    <option>Not Selected</option>
+  {{/x-select}}
+</p>
+<p class="spec-selected-quantity">Selected Quantity: {{selectedQuantity}}</p>


### PR DESCRIPTION
- Test for the resultant behavior: the initial value was not selected

I'm not sure I'm happy with the test here since it doesn't explicitly test that the bound value isn't changed initially, just the result: that the value wasn't selected because it had been updated to null. Also feels like it might be feel a bit random when the dummy is used as documentation.

Fixes #112 