### PR TITLE
use html attrbiute case for one way attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ The selections array will be initialized to an empty array if not present.
 In x-select v2.2.0 we introduced a way to disable two way data
 binding, which is enabled by default. If you would like to only mutate
 the value of x-select through actions you can pass an attribute called
-`oneWay` and set it to `true`. This will disable two way data binding.
+`one-way` and set it to `true`. This will disable two way data binding.
 
 ```hbs
-{{#x-select value=willNotChangeOnSelection oneWay=true}}
+{{#x-select value=willNotChangeOnSelection one-way=true}}
   {{#x-option value="hello" selected=true}}Hello{{/x-option}}
   {{#x-option value="world"}}World{{/x-option}}
 {{/x-select}}
@@ -106,7 +106,9 @@ the value of x-select through actions you can pass an attribute called
 
 If you select the `World` option in the example above, it will not
 change the value (`willNotChangeOnSelection`) to `world`. Without
-`oneWay=true` it would change the value.
+`one-way=true` it would change the value.
+
+> Note: In x-select 3.x one way binding will be the default.
 
 ## Action and Action Arguments
 

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -58,11 +58,11 @@ export default Ember.Component.extend({
    * value of x-select will not be updated when changing options, you
    * would need to do mutate the value through an action.
    *
-   * @property oneWay
+   * @property one-way
    * @type Boolean
    * @ default false
    */
-  oneWay: false,
+  'one-way': false,
 
   /**
    * The collection of options for this select box. When options are
@@ -83,7 +83,7 @@ export default Ember.Component.extend({
    */
   change(event) {
 
-    if(!this.get('oneWay')) {
+    if(!this.get('one-way')) {
       this._updateValue();
     }
 

--- a/tests/integration/components/two-way-data-binding-test.js
+++ b/tests/integration/components/two-way-data-binding-test.js
@@ -15,7 +15,7 @@ describeComponent(
       beforeEach(function() {
         this.set('make', 'ford');
         this.render(hbs`
-          {{#x-select value=make oneWay=true}}
+          {{#x-select value=make one-way=true}}
             {{#x-option value="ford"}}Ford{{/x-option}}
             {{#x-option value="chevy"}}Chevy{{/x-option}}
             {{#x-option value="dodge" class="spec-dodge-option"}}Dodge{{/x-option}}


### PR DESCRIPTION
In handlebars, component attributes that are bound from HTML generally follow html attribute naming conventions which is kebab case, (e.g. `data-href`) This is because components are converging conceptually on being simply custom html elements.

This changes the one-way property to use the prevailing convention for naming multi word html attributes.