### PR TITLE
fix the one-way binding attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ The selections array will be initialized to an empty array if not present.
 In x-select v2.2.0 we introduced a way to disable two way data
 binding, which is enabled by default. If you would like to only mutate
 the value of x-select through actions you can pass an attribute called
-`oneWay` and set it to `true`. This will disable two way data binding.
+`one-way` and set it to `true`. This will disable two way data binding.
 
 ```hbs
-{{#x-select value=willNotChangeOnSelection oneWay=true}}
+{{#x-select value=willNotChangeOnSelection one-way=true}}
   {{#x-option value="hello" selected=true}}Hello{{/x-option}}
   {{#x-option value="world"}}World{{/x-option}}
 {{/x-select}}
@@ -106,7 +106,7 @@ the value of x-select through actions you can pass an attribute called
 
 If you select the `World` option in the example above, it will not
 change the value (`willNotChangeOnSelection`) to `world`. Without
-`oneWay=true` it would change the value.
+`one-way=true` it would change the value.
 
 ## Action and Action Arguments
 

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -101,7 +101,7 @@ export default Ember.Component.extend({
    * component's action with the component, x-select value, and the jQuery event.
    */
   click(event) {
-    this.sendAction('onclick', this, this.get('value'), event);
+    this.sendAction('onclick', this, this._getValue(), event);
   },
 
   /**
@@ -109,7 +109,7 @@ export default Ember.Component.extend({
    * component's action with the component, x-select value, and the jQuery event.
    */
   blur(event) {
-    this.sendAction('onblur', this, this.get('value'), event);
+    this.sendAction('onblur', this, this._getValue(), event);
   },
 
   /**
@@ -117,7 +117,7 @@ export default Ember.Component.extend({
    * component's action with the component, x-select value, and the jQuery event.
    */
   focusOut(event) {
-    this.sendAction('onfocusout', this, this.get('value'), event);
+    this.sendAction('onfocusout', this, this._getValue(), event);
   },
 
   /**

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -67,6 +67,7 @@ export default Ember.Component.extend({
    * @default false
    */
   'one-way': false,
+  'oneWay': Ember.computed.alias('one-way'),
 
   /**
    * The collection of options for this select box. When options are

--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -62,11 +62,11 @@ export default Ember.Component.extend({
    *   {{!options here ....}}
    * {{/x-select}}
    *
-   * @property oneWay
+   * @property one-way
    * @type Boolean
    * @default false
    */
-  oneWay: false,
+  'one-way': false,
 
   /**
    * The collection of options for this select box. When options are
@@ -86,13 +86,14 @@ export default Ember.Component.extend({
    * component's action with the current value.
    */
   change(event) {
+    let nextValue = this._getValue();
 
-    if(!this.get('oneWay')) {
-      this._updateValue();
+    if (!this.get('one-way')) {
+      this.set('value', nextValue);
     }
 
-    this.sendAction('action', this.get('value'), this);
-    this.sendAction('onchange', this, this.get('value'), event);
+    this.sendAction('action', nextValue, this);
+    this.sendAction('onchange', this, nextValue, event);
   },
 
   /**
@@ -120,52 +121,36 @@ export default Ember.Component.extend({
   },
 
   /**
-   * Updates `value` with the object associated with the selected option tag
+   * Reads the current selection from this select's options.
+   *
+   * If this is a multi-select, then the value will be an
+   * array. Otherwise, it will be a single value which could be null.
    *
    * @private
+   * @return {Array|Object} the current selection
    */
-  _updateValueSingle: function(){
-    var option = this.get('options').find(function(option) {
+  _getValue() {
+    let options = this.get('options').filter(function(option) {
       return option.$().is(':selected');
     });
 
-    if (option) {
-      this.set('value', option.get('value'));
+    if (this.get('multiple')) {
+      return Ember.A(options).mapBy('value');
     } else {
-      this.set('value', null);
+      let option = options[0];
+      return option ? option.get('value') : null;
     }
   },
 
   /**
-   * Updates `value` with an array of objects associated with the selected option tags
-   *
+   * Reads the current value and sets it.
    * @private
-   */
-  _updateValueMultiple: function() {
-    var options = this.get('options').filter(function(option) {
-      return option.$().is(':selected');
-    });
-
-    this.set('value', Ember.A(options).mapBy('value'));
-  },
-
-  /**
-   * A utility method to determine if the select is multiple or single and call
-   * its respective method to update the value.
-   *
-   * @private
-   * @utility
    */
   _updateValue: function() {
     if (this.isDestroying || this.isDestroyed) {
       return;
     }
-
-    if (this.get('multiple')) {
-      this._updateValueMultiple();
-    } else {
-      this._updateValueSingle();
-    }
+    this.set('value', this._getValue());
   },
 
   /**

--- a/tests/integration/components/two-way-data-binding-test.js
+++ b/tests/integration/components/two-way-data-binding-test.js
@@ -15,8 +15,12 @@ describeComponent(
       beforeEach(function() {
         this.set('make', 'ford');
         this.set('capture', (value)=> this.value = value);
+        this.set('onClick', (x, value)=> this.click = value);
+        this.set('onFocusOut', (x, value)=> this.focusOut = value);
+        this.set('onBlur', (x, value)=> this.blur = value);
+
         this.render(hbs`
-          {{#x-select value=make one-way=true action=capture}}
+          {{#x-select value=make one-way=true action=capture onclick=onClick onfocusout=onFocusOut onblur=onBlur}}
             {{#x-option value="ford"}}Ford{{/x-option}}
             {{#x-option value="chevy"}}Chevy{{/x-option}}
             {{#x-option value="dodge" class="spec-dodge-option"}}Dodge{{/x-option}}
@@ -34,6 +38,21 @@ describeComponent(
       it("passes the new value to the action closure ", function() {
         expect(this.value).to.equal('dodge');
       });
+
+      describe("upon subsequent triggering of a DOM event", function() {
+        beforeEach(function() {
+          this.$('.x-select')
+            .trigger('click')
+            .trigger('focusout')
+            .trigger('blur');
+        });
+        it("fires bound handlers with the new value", function() {
+          expect(this.click).to.equal('dodge');
+          expect(this.focusOut).to.equal('dodge');
+          expect(this.blur).to.equal('dodge');
+        });
+      });
+
     });
   }
 );

--- a/tests/integration/components/two-way-data-binding-test.js
+++ b/tests/integration/components/two-way-data-binding-test.js
@@ -14,8 +14,9 @@ describeComponent(
     describe("changing the selection with two way data binding disabled", function() {
       beforeEach(function() {
         this.set('make', 'ford');
+        this.set('capture', (value)=> this.value = value);
         this.render(hbs`
-          {{#x-select value=make oneWay=true}}
+          {{#x-select value=make one-way=true action=capture}}
             {{#x-option value="ford"}}Ford{{/x-option}}
             {{#x-option value="chevy"}}Chevy{{/x-option}}
             {{#x-option value="dodge" class="spec-dodge-option"}}Dodge{{/x-option}}
@@ -29,6 +30,9 @@ describeComponent(
 
       it("doesn't mutate the value", function() {
         expect(this.get('make')).to.equal("ford");
+      });
+      it("passes the new value to the action closure ", function() {
+        expect(this.value).to.equal('dodge');
       });
     });
   }


### PR DESCRIPTION
This separates the `read` operation from the `write` operation which turns out to be a very handy thing. It turns out that reading a multi select value and a single select value is the only difference.

So upon an update, we read the next value (which depends on the selection type) and then, regardless of whethere it is multi or not, we `set` the value if it is a two-way binding.

fixes #131, closes #129 

