### PR TITLE
Fire action when one-way is true and no default value provided

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -67,6 +67,13 @@ export default Ember.Component.extend({
    * @default false
    */
   'one-way': false,
+
+  /**
+   * oneWay alias is a backward-compatible attribute for a release that existed
+   * for a short time
+   *
+   * @deprecated
+   */
   'oneWay': Ember.computed.alias('one-way'),
 
   /**
@@ -162,7 +169,11 @@ export default Ember.Component.extend({
    */
   _setDefaultValues: function() {
     if (this.get('value') == null) {
-      this._updateValue();
+      if (!this.get('one-way')) {
+        this._updateValue();
+      }
+
+      this.sendAction('action', this._getValue());
     }
   },
 

--- a/tests/integration/components/two-way-data-binding-test.js
+++ b/tests/integration/components/two-way-data-binding-test.js
@@ -63,10 +63,10 @@ describeComponent(
         });
 
         this.render(hbs`
-          {{#x-select value=make one-way=true action=(action selectAction)}}
-            {{#x-option value="ford" class="spec-ford-option"}}Ford{{/x-option}}
-            {{#x-option value="chevy"}}Chevy{{/x-option}}
-            {{#x-option value="dodge" class="spec-dodge-option"}}Dodge{{/x-option}}
+          {{#x-select value=make one-way=true action=selectAction}}
+            {{#x-option value="fordValue" class="spec-ford-option"}}Ford{{/x-option}}
+            {{#x-option value="chevyValue"}}Chevy{{/x-option}}
+            {{#x-option value="dodgeValue" class="spec-dodge-option"}}Dodge{{/x-option}}
           {{/x-select}}
         `);
       });
@@ -76,7 +76,7 @@ describeComponent(
       });
 
       it("sets the default value to the first element", function() {
-        expect(this.get('make')).to.equal("ford");
+        expect(this.get('make')).to.equal("fordValue");
       });
 
       it("invokes the select action on init", function() {

--- a/tests/integration/components/two-way-data-binding-test.js
+++ b/tests/integration/components/two-way-data-binding-test.js
@@ -52,6 +52,36 @@ describeComponent(
           expect(this.blur).to.equal('dodge');
         });
       });
+    });
+
+    describe("default value of null with two way data binding disabled", function() {
+      beforeEach(function() {
+        this.set('make', null);
+        this.set('selectAction', (value) => {
+          this.set("make", value);
+          this.set("wasCalled", true);
+        });
+
+        this.render(hbs`
+          {{#x-select value=make one-way=true action=(action selectAction)}}
+            {{#x-option value="ford" class="spec-ford-option"}}Ford{{/x-option}}
+            {{#x-option value="chevy"}}Chevy{{/x-option}}
+            {{#x-option value="dodge" class="spec-dodge-option"}}Dodge{{/x-option}}
+          {{/x-select}}
+        `);
+      });
+
+      it("displays the first item in the list", function() {
+        expect(this.$('select option:selected').text()).to.equal("Ford");
+      });
+
+      it("sets the default value to the first element", function() {
+        expect(this.get('make')).to.equal("ford");
+      });
+
+      it("invokes the select action on init", function() {
+        expect(this.get("wasCalled")).to.equal(true);
+      });
 
     });
   }


### PR DESCRIPTION
This was a small fix to make sure when `one-way` is set to `true` we fire the action on init rather than try to bind the data. 

This needs a 2nd pair of eyes, I'd like @cafreeman see if this fixes his issues using this with `x-form`.