### PR TITLE
Extract select test helper to an exported function

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,10 @@ injected the test helper into your app.
 
 #### Using the test helper
 
-As of version 1.1.3 we support both multiselects and regular selects. To use, you
-need to specify the class on the select as the first argument and the rest
-of the arguments are the options you'd like to select. For example:
+We support both multiselects and regular selects. To use, you
+need to specify the class on the select (or a jquery object) as the
+first argument and the rest of the arguments are the options you'd
+like to select. For example:
 
 ```js
 //... Single select
@@ -165,9 +166,21 @@ of the arguments are the options you'd like to select. For example:
 Multiselect
 ```js
 //... Multiselect
-  select('.my-drop-down', 'My Option', 'My Option Two', 'My Option Three');
+  select(Ember.$('.my-drop-down'), 'My Option', 'My Option Two', 'My Option Three');
 //...
 ```
+
+##### Component Integration tests
+
+To use the select helper in component integration
+tests you have to import the select function into your test:
+
+``` javascript
+  import { select } from 'yourappname/tests/helpers/x-select';
+```
+
+And then you can use the helper like you would normally.
+
 
 #### Why am I getting a JSHint error?
 
@@ -179,8 +192,8 @@ You need to either run the generator (`ember g emberx-select`) or import the tes
 `test-helper.js` file:
 
 ```js
-import registerSelectHelper from './helpers/register-select-helper';
-registerSelectHelper();
+import xSelectHelper from './helpers/x-select';
+xSelectHelper();
 ```
 
 ## EmberX

--- a/blueprints/emberx-select/index.js
+++ b/blueprints/emberx-select/index.js
@@ -8,12 +8,12 @@ module.exports = {
   afterInstall: function() {
     // Import statement
     var firstFile = 'tests/test-helper.js';
-    var firstText = "import registerSelectHelper from './helpers/register-select-helper';";
+    var firstText = "import xSelectHelper from './helpers/x-select';";
     var afterFirstText = "import resolver from './helpers/resolver';" + EOL;
 
     // Execution of registration function
     var secondFile = 'tests/test-helper.js';
-    var secondText = "registerSelectHelper();";
+    var secondText = "xSelectHelper();";
     var afterSecondText = firstText + EOL;
 
     return this.insertIntoFile(firstFile, firstText, { after: afterFirstText}).then(function() {

--- a/test-support/helpers/register-select-helper.js
+++ b/test-support/helpers/register-select-helper.js
@@ -1,18 +1,33 @@
 import Ember from 'ember';
 
-export default function() {
-  Ember.Test.registerAsyncHelper('select', function(app, selector, ...texts) {
-    let $options = app.testHelpers.findWithAssert(`${selector} option`);
+// TODO:
+// Can you pass an object instead of a string?
+// Can you make it not case sensastive?
+// Rename the file / move the select function?
+export function select(selector, ...texts) {
+  let $options = Ember.$(`${selector} option`);
 
+  if (!$options.length) {
+    throw `No options found in ${selector}` ;
+  }
 
-    $options.each(function() {
-      let $option = Ember.$(this);
+  $options.each(function() {
+    let $option = Ember.$(this);
 
-      Ember.run(() => {
-        this.selected = texts.some(text => $option.is(`:contains('${text}')`));
-        $option.trigger('change');
-      });
+    Ember.run(() => {
+      this.selected = texts.some(text => $option.is(`:contains('${text}')`));
+
+      if(this.selected) {
+        $option.prop('selected', true).trigger('change');
+      }
+
     });
+  });
+}
+
+export default function() {
+  Ember.Test.registerAsyncHelper('select', function(app, selector, texts) {
+    select(selector, texts);
 
     return app.testHelpers.wait();
   });

--- a/test-support/helpers/x-select.js
+++ b/test-support/helpers/x-select.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
+import jQuery from 'jquery';
 
 // TODO:
-// Can you pass an object instead of a string?
-// Can you make it not case sensastive?
 // Rename the file / move the select function?
 export function select(selector, ...texts) {
-  let $options = Ember.$(`${selector} option`);
+  let $select = selector instanceof jQuery ? selector : Ember.$(selector);
+  let $options = $select.find(`option`);
 
   if (!$options.length) {
     throw `No options found in ${selector}` ;
@@ -15,12 +15,16 @@ export function select(selector, ...texts) {
     let $option = Ember.$(this);
 
     Ember.run(() => {
-      this.selected = texts.some(text => $option.is(`:contains('${text}')`));
+      this.selected = texts.some((text) => {
+        // uppercase both texts so the helper isn't case sensastive.
+        let optionText = $option.text().trim().toUpperCase();
+
+        return optionText === text.toUpperCase();
+      });
 
       if(this.selected) {
         $option.prop('selected', true).trigger('change');
       }
-
     });
   });
 }

--- a/test-support/helpers/x-select.js
+++ b/test-support/helpers/x-select.js
@@ -1,8 +1,13 @@
 import Ember from 'ember';
 import jQuery from 'jquery';
 
-// TODO:
-// Rename the file / move the select function?
+/**
+ * Picks an option from the select and sets it to be `selected` in the DOM.
+ *
+ * @method select
+ * @param {string|<jQuery>} selector - selector for the select to pick from.
+ * @param {string} texts - text of the option you are picking
+ */
 export function select(selector, ...texts) {
   let $select = selector instanceof jQuery ? selector : Ember.$(selector);
   let $options = $select.find(`option`);

--- a/tests/integration/components/two-way-data-binding-test.js
+++ b/tests/integration/components/two-way-data-binding-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import { describe, beforeEach } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
+import { select } from 'dummy/tests/helpers/register-select-helper';
 
 describeComponent(
   'two-way-data-binding',
@@ -29,7 +30,7 @@ describeComponent(
       });
 
       beforeEach(function() {
-        this.$('.spec-dodge-option').prop('selected', true).trigger('change');
+        select('.x-select', 'Dodge');
       });
 
       it("doesn't mutate the value", function() {

--- a/tests/integration/components/two-way-data-binding-test.js
+++ b/tests/integration/components/two-way-data-binding-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import { describe, beforeEach } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
-import { select } from 'dummy/tests/helpers/register-select-helper';
+import { select } from 'dummy/tests/helpers/x-select';
 
 describeComponent(
   'two-way-data-binding',
@@ -30,7 +30,7 @@ describeComponent(
       });
 
       beforeEach(function() {
-        select('.x-select', 'Dodge');
+        select(this.$(), 'Dodge');
       });
 
       it("doesn't mutate the value", function() {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import resolver from './helpers/resolver';
 import { setResolver } from 'ember-mocha';
-import registerSelectHelper from './helpers/register-select-helper';
-registerSelectHelper();
+import xSelectHelper from './helpers/x-select';
+xSelectHelper();
 
 
 setResolver(resolver);


### PR DESCRIPTION
Ready for review.

This makes the `select` helper more robust. First and foremost you can now import the select helper directly:

```js
import { select } from 'yourappname/tests/helpers/x-select';
```
Also you can pass a jquery object to the helper instead of just a string. This is useful in component integration tests: `select(this.$('.x-select'), 'option')`. The options are now not case sensitive. 

## Breaking changes
- Renamed the file name to `x-select`