### PR TITLE
Fire action on x-option when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ component, the value, and the jQuery event.
 `onclick` fires when x-select is clicked. When the action fires it
 sends three arguments: the component, the value, and the jQuery event.
 
+**on-disable** (x-option)
+
+`on-disable` fires when x-option detects a change to its `disabled`
+attribute. When the action fires it sends two arguments: the value
+and if it is disabled (boolean).
+
 ### Test Helpers
 
 Since `emberx-select` uses internal identifiers as the `value` attribute, it

--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -49,6 +49,7 @@ export default Ember.Component.extend({
     this._super.apply(...arguments);
 
     if(oldAttrs && !!oldAttrs.disabled) {
+      // Undefined also means the option is not disabled.
       let oldDisabled = !!oldAttrs.disabled.value;
 
       if(this.get('disabled') !== oldDisabled) {

--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -45,10 +45,10 @@ export default Ember.Component.extend({
     }
   }),
 
-  didUpdateAttrs({oldAttrs: { disabled }}) {
+  didReceiveAttrs({oldAttrs}) {
     this._super.apply(...arguments);
 
-    if(this.get('disabled') !== disabled) {
+    if(oldAttrs && this.get('disabled') !== !!oldAttrs.disabled.value) {
       this.sendAction('on-disable', this.get('value'), this.get('disabled'));
     }
   },

--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -45,6 +45,11 @@ export default Ember.Component.extend({
     }
   }),
 
+  // TODO, I don't want to use an observer. And the name isn't great..
+  disableToggle: Ember.observer('disabled', function() {
+    this.sendAction('on-disable', this.get('value'), this.get('disabled'));
+  }),
+
   /**
    * Register this x-option with the containing `x-select`
    *

--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -45,10 +45,13 @@ export default Ember.Component.extend({
     }
   }),
 
-  // TODO, I don't want to use an observer. And the name isn't great..
-  disableToggle: Ember.observer('disabled', function() {
-    this.sendAction('on-disable', this.get('value'), this.get('disabled'));
-  }),
+  didUpdateAttrs({oldAttrs: { disabled }}) {
+    this._super.apply(...arguments);
+
+    if(this.get('disabled') !== disabled) {
+      this.sendAction('on-disable', this.get('value'), this.get('disabled'));
+    }
+  },
 
   /**
    * Register this x-option with the containing `x-select`

--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -48,8 +48,12 @@ export default Ember.Component.extend({
   didReceiveAttrs({oldAttrs}) {
     this._super.apply(...arguments);
 
-    if(oldAttrs && this.get('disabled') !== !!oldAttrs.disabled.value) {
-      this.sendAction('on-disable', this.get('value'), this.get('disabled'));
+    if(oldAttrs && !!oldAttrs.disabled) {
+      let oldDisabled = !!oldAttrs.disabled.value;
+
+      if(this.get('disabled') !== oldDisabled) {
+        this.sendAction('on-disable', this.get('value'), this.get('disabled'));
+      }
     }
   },
 

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "ember-mocha": "0.8.8",
     "chai-jquery": "~2.0.0",
+    "sinon-chai": "~2.8.0",
     "ember": "~2.3.0",
     "ember-cli-shims": "0.1.1"
   }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,6 +15,7 @@ module.exports = function(defaults) {
    */
 
   app.import('bower_components/chai-jquery/chai-jquery.js', {type: 'test'});
+  app.import('bower_components/sinon-chai/lib/sinon-chai.js', {type: 'test'});
 
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-mocha": "0.10.4",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
+    "ember-cli-mocha": "0.10.4",
     "ember-cli-release": "^0.2.9",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -35,6 +35,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.5.1",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/integration/components/x-select-actions-test.js
+++ b/tests/integration/components/x-select-actions-test.js
@@ -1,0 +1,54 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import { describeComponent, it } from 'ember-mocha';
+import { beforeEach, describe } from 'mocha';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+describeComponent.only(
+  'x-select-actions',
+  'Integration: XSelectActionsComponent',
+  {
+    integration: true
+  },
+  function() {
+    describe("x-option actions", function() {
+      beforeEach(function() {
+        this.set('disabledProp', false);
+        this.set('handleDisable', sinon.spy());
+
+        this.render(hbs`
+          {{#x-select value=value as |xs|}}
+            {{#xs.option value="Hello" on-disable=(action handleDisable) disabled=disabledProp class="test-xs-option"}}
+              Hello
+            {{/xs.option}}
+          {{/x-select}}
+        `);
+      });
+
+      it('the option is not disabled', function() {
+        expect(this.$('.test-xs-option').prop('disabled')).to.equal(false);
+      });
+
+      describe("disabling an option", function() {
+        beforeEach(function() {
+          this.set('disabledProp', true);
+        });
+
+        it("disables the option", function() {
+          expect(this.$('.test-xs-option').prop('disabled')).to.equal(true);
+        });
+
+        it("calls the disable action", function() {
+          expect(this.get('handleDisable')).to.have.been.called;
+        });
+
+        it("has the correct arguments passed to the action", function() {
+          expect(this.get('handleDisable').args[0][0]).to.equal('Hello', 'First argument should be the value');
+          expect(this.get('handleDisable').args[0][1]).to.equal(true, 'Second argument should be the disabled boolean');
+        });
+
+      });
+    });
+  }
+);

--- a/tests/integration/components/x-select-actions-test.js
+++ b/tests/integration/components/x-select-actions-test.js
@@ -14,7 +14,6 @@ describeComponent.only(
   function() {
     describe("x-option actions", function() {
       beforeEach(function() {
-        this.set('disabledProp', false);
         this.set('handleDisable', sinon.spy());
 
         this.render(hbs`
@@ -24,10 +23,15 @@ describeComponent.only(
             {{/xs.option}}
           {{/x-select}}
         `);
+        this.set('disabledProp', false);
       });
 
       it('the option is not disabled', function() {
         expect(this.$('.test-xs-option').prop('disabled')).to.equal(false);
+      });
+
+      it("does not fire the action", function() {
+        expect(this.get('handleDisable')).to.not.have.been.called;
       });
 
       describe("disabling an option", function() {
@@ -46,6 +50,19 @@ describeComponent.only(
         it("has the correct arguments passed to the action", function() {
           expect(this.get('handleDisable').args[0][0]).to.equal('Hello', 'First argument should be the value');
           expect(this.get('handleDisable').args[0][1]).to.equal(true, 'Second argument should be the disabled boolean');
+        });
+
+        describe("setting the same value", function() {
+          beforeEach(function() {
+            this.set('disabledProp', true);
+          });
+
+          it("doesn't fire the action twice", function() {
+            // Once because this spy has already been called in the
+            // parent describe
+            expect(this.get('handleDisable')).to.have.been.calledOnce;
+          });
+
         });
 
       });

--- a/tests/integration/components/x-select-actions-test.js
+++ b/tests/integration/components/x-select-actions-test.js
@@ -5,7 +5,7 @@ import { beforeEach, describe } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-describeComponent.only(
+describeComponent(
   'x-select-actions',
   'Integration: XSelectActionsComponent',
   {


### PR DESCRIPTION
The goal for this is to close #136. We would like to fire an action any time an option is disabled. With that action we send the disabled value (true or false) & the value of that option. 

@jameshoward I would love to get your feedback on this. 

### TODO
- [x] Add readme docs for new action