### PR TITLE
coalesce registering and unregistering options

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -128,6 +128,10 @@ export default Ember.Component.extend({
    * @private
    */
   _setDefaultValues: function() {
+    Ember.run.once(this, this.__setDefaultValues);
+  },
+
+  __setDefaultValues: function() {
     if (this.get('value') === null) {
       this.sendAction('action', this._getValue());
     }


### PR DESCRIPTION
tl;dr we can call the `_setDefaultValues()` function only once when rendering
a bunch of components or destroying a bunch of components.

If you have a list with a large amount of selects (~ 40 in our app),
the `_setDefaultValues` function can get pretty expensive as it has to query
the DOM every time. This gets slowly more costly to query as registering
40 `<option>` elements calls the `_setDefaultValues` function 40 times.

In addition to the 40 times the function is called, the number of
elements slowly grows as well. This ends up being n^2\2. After this PR, it's just 1 time.