### PR TITLE
call willDestroyElement's this._super last

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -148,9 +148,8 @@ export default Ember.Component.extend({
    * @override
    */
   willDestroyElement: function() {
-    this._super.apply(this, arguments);
-
     this.$().off('blur');
+    this._super.apply(this, arguments);
   },
 
   /**


### PR DESCRIPTION
In Ember, willDestroyElement is a cleanup or destructor hook. This means
when it is overridden, `this._super` should be called last to avoid
collisions with Ember's cleanup code.