### PR TITLE
reduce number of components searched

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 
 var isArray = Ember.isArray;
 
+const isSelectedOption = (option) => option.$().is(':selected');
+
 /**
  * Wraps a native <select> element so that it can be object and
  * binding aware. It is used in conjuction with the
@@ -109,16 +111,30 @@ export default Ember.Component.extend({
    * @return {Array|Object} the current selection
    */
   _getValue() {
-    let options = this.get('options').filter(function(option) {
-      return option.$().is(':selected');
-    });
+    return this.get('multiple') ? this._findMultipleValues() : this._findSingleValue();
+  },
 
-    if (this.get('multiple')) {
-      return Ember.A(options).mapBy('value');
-    } else {
-      let option = options[0];
-      return option ? option.get('value') : null;
-    }
+  /**
+   * Finds all selected values from all `x-option`
+   * children. Used when this.get('multiple') === true
+   *
+   * @private
+   * @return {Array} all the values from selected x-options
+  */
+  _findMultipleValues() {
+    return this.get('options').filter(isSelectedOption).map(option => option.get('value'));
+  },
+
+  /**
+   * Returns the value of the first selected `x-option`.
+   * Used when `this.get('multiple') !== true`
+   *
+   * @private
+   * @return {Object} the value of the first select `x-option`, or null
+  */
+  _findSingleValue() {
+    const selectedValue = this.get('options').find(isSelectedOption);
+    return selectedValue ? selectedValue.get('value') : null;
   },
 
   /**


### PR DESCRIPTION
This commit has 2 goals:

1) A small refactoring of the getValue method to split out the
multiple/single value cases.
2) Decrease the number of elements `_getValue` searches through if
possible. `Array.prototype.find` stops iterating on the array when the
callback returns truthy. `options` is an `Ember.A` which means it should
polyfill the `Array.prototype.find` method.

Say you have an array like:

```javascript
const values = [1, 2, 3];
```

If we're looking for the value `2`, we only want to search the array two
times, because the number 2 is found on the second iteration.

This reduces the amount of work we have to do on larger arrays because
we can bail if the element is found early. While this doesn't matter
much on an array of 5, it can matter more with bigger arrays especially
since we're querying the DOM.