### PR TITLE
don't share `options` arrays between x-select instances

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-var isArray = Ember.isArray;
+const {
+  isArray,
+  computed,
+} = Ember;
 
 /**
  * Wraps a native <select> element so that it can be object and
@@ -53,7 +56,9 @@ export default Ember.Component.extend({
    * @private
    * @property options
    */
-  options: Ember.A([]),
+  options: computed(function() {
+    return Ember.A([]);
+  }),
 
   /**
    * Bound to the `tabindex` attribute on the native <select> tag.


### PR DESCRIPTION
In Ember, `.extend` is shorthand for defining properties on the
prototype. Anything put on the prototype will be shared by all of its
instances.

For example:

```javascript
const Test = Ember.Object.extend({
  results: []
});

const test1 = Test.create();
const test2 = Test.create();

test1.get('results').push(1);
test1.get('results'); // [1]
test2.get('results'); // [1]
```

`x-select` instances were sharing `options` between instances. While
this didn't manifest itself in any user-facing bugs, it will in the
future in subtle ways.

This PR changes `options` to be a computed property so that each
instance gets its own `options` array.