### PR TITLE
Fix bug where undefined initial values were changed to null

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -153,7 +153,7 @@ export default Ember.Component.extend({
   },
 
   __setDefaultValues: function() {
-    if (this.get('value') === null) {
+    if (this.get('value') == null) {
       this.sendAction('action', this._getValue());
     }
   },

--- a/tests/acceptance/default-values-test.js
+++ b/tests/acceptance/default-values-test.js
@@ -61,6 +61,14 @@ describe('XSelect: Default Values', function() {
       expect($(".spec-selected-quantity:contains('Selected Quantity: 0')")).to.exist;
     });
 
+    it('sets the selected property on the correct default option', function() {
+      expect($(".spec-car-trim option:contains('Sport')")).to.be.selected;
+    });
+
+    it('initializes with the correct explicit value if one is present even if that value is undefined', function() {
+      expect($(".spec-selected-trim:contains('Selected Trim: Sport')")).to.exist;
+    });
+
     describe("Changing the value on fields with default values", function() {
       beforeEach(function() {
         select('.spec-car-make', 'Toyota');

--- a/tests/dummy/app/controllers/default-value.js
+++ b/tests/dummy/app/controllers/default-value.js
@@ -8,7 +8,7 @@ export default Ember.Controller.extend(Cars, {
 
   carModel: null,
 
-  trim: null,
+  trim: undefined,
 
   selectedQuantity: 0,
 


### PR DESCRIPTION
@Robdel12 I'm not sure the impetus for changing the conditional in #140 [here](https://github.com/thefrontside/emberx-select/commit/fc7fdba978c114182937919d63dfd5d1e7f0a1ae#diff-61de3d9cb98ddeb2c88de3a2d3b03af3R131) but I found this to cause default values to not bind correctly if the property was `undefined`.  

For the test I co-opted a piece of the existing acceptance test that was not actually being tested.

/cc @fivetanley 