### PR TITLE
guard against __setDefaultValues being called during teardown

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -153,7 +153,8 @@ export default Ember.Component.extend({
   },
 
   __setDefaultValues: function() {
-    if (this.get('value') == null) {
+    const canSet = !this.isDestroying && !this.isDestroyed;
+    if (canSet && this.get('value') == null) {
       this.sendAction('action', this._getValue());
     }
   },


### PR DESCRIPTION
This restores a guard that used to exist around trying to set a default value while the component is being torn down.  The changes from #152 made this necessary again as `this.get('value')` is `null` during teardown which was causing bad things to happen.