### PR TITLE
Allow ember-source npm package to work.

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -39,6 +39,20 @@ module.exports = {
           'ember': 'canary'
         }
       }
+    },
+    {
+      name: 'ember-source',
+      allowedToFail: true,
+      bower: {
+        dependencies: {
+          'ember': null
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': '^2.11.0-alpha.1'
+        }
+      }
     }
   ]
 };

--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ module.exports = {
     var VersionChecker = require('ember-cli-version-checker');
 
     var checker = new VersionChecker(this);
-    var dep = checker.for('ember', 'bower');
+    var dep = checker.for('ember-source', 'npm');
+
+    if (!dep.version) {
+      dep = checker.for('ember', 'bower');
+    }
 
     var isBetaOrCanary = ['beta', 'canary'].filter(function(version) {
       return dep.version.indexOf(version) >= 0;

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "ember select component"
   ],
   "dependencies": {
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-version-checker": "^1.1.6",
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-version-checker": "^1.1.6"
   },
   "ember-addon": {
     "demoURL": "https://thefrontside.github.io/emberx-select",


### PR DESCRIPTION
In the near future (ember-cli@2.11) Ember itself will be obtained from the `ember-source` npm package (instead of via Bower). 

This PR paves the way for additional testing (current emberx-select errors when Ember is not present via Bower), and adds ember-source to an ember-try scenario.