### PR TITLE
Add forced value-setting as Edge workaround

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -194,6 +194,12 @@ export default Ember.Component.extend({
     this.$().on('blur', (event) => {
       this.blur(event);
     });
+
+    // FIXME this is an unfortunate workaround for an Edge bug for selects with required:
+    // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8794503/
+    let value = this.$().val();
+    this.$().val(`${value}-fake-edge-😳`);
+    this.$().val(value);
   },
 
   /**


### PR DESCRIPTION
This is a hackish compensation for a [bug in Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8794503/). I don’t think it’s necessarily something you’d even want in your codebase because it’s so unsightly, but I’m submitting it to get your feedback. (Also it’s branched off `v2.2.2` because I haven’t yet converted to contextual components.)

Without this, a select with the required flag is marked as invalid until you change the value. You can change the value yourself and then change it back to the default, but even that workaround fails if the select only has one value.

I don’t really feel like this is an acceptable solution, but `travis-web` users on Edge are unable to add cron jobs on repositories with only one branch because of it. Even on repositories with multiple branches, all three fields have to be changed before a cron can be added:

![image](https://cloud.githubusercontent.com/assets/43280/21431639/0e6f38a4-c836-11e6-9237-e9eeaf29dbb9.png)

Do you have any better ideas on how to address this? I’d love to find a cleaner way!