### PR TITLE
Fixed Bug with computed properties (to v2.2.3)

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -223,12 +223,13 @@ export default Ember.Component.extend({
     }
   })),
 
+
   /**
    * @private
    */
   registerOption: function(option) {
     this.get('options').addObject(option);
-    this._setDefaultValues();
+    Ember.run.once(this, '_setDefaultValues');
   },
 
   /**
@@ -239,7 +240,7 @@ export default Ember.Component.extend({
 
     // We don't want to update the value if we're tearing the component down.
     if (!this.get('isXSelectDestroying')) {
-      this._updateValue();
+      Ember.run.once(this, '_updateValue');
     }
   }
 });


### PR DESCRIPTION
From the original commit: 
> There was an issue when a computed property was changed... The selected property on options fired multiple times and threw a series of deprecation warnings. See #158

> Thanks to @bmass02

Back porting this to v2.2.3