### PR TITLE
Fix  #181 didReceiveAttrs arguments deprecation

### DIFF
--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -45,17 +45,20 @@ export default Ember.Component.extend({
     }
   }),
 
-  didReceiveAttrs({oldAttrs}) {
+  didReceiveAttrs() {
     this._super.apply(...arguments);
 
-    if(oldAttrs && !!oldAttrs.disabled) {
-      // Undefined also means the option is not disabled.
-      let oldDisabled = !!oldAttrs.disabled.value;
+    let oldDisabled = this.get('_oldDisabled');
+
+    if(oldDisabled !== undefined && !oldDisabled) {
+      // Undefined means the first time
 
       if(this.get('disabled') !== oldDisabled) {
         this.sendAction('on-disable', this.get('value'), this.get('disabled'));
       }
     }
+
+    this.set('_oldDisabled', this.get('disabled'));
   },
 
   /**


### PR DESCRIPTION
Fixes the didReceiveAttrs() lifecycle hook arguments deprecation warning. I did this by following the guidelines given in [this RFC](https://github.com/emberjs/rfcs/blob/master/text/0191-deprecate-component-lifecycle-hook-args.md\#didreceiveattrs)