### PR TITLE
Remove Edge workaround, fixed in Edge 16

### DIFF
--- a/addon/components/x-select.js
+++ b/addon/components/x-select.js
@@ -220,14 +220,6 @@ export default Ember.Component.extend({
     this.$().on('blur', (event) => {
       this.blur(event);
     });
-
-    // FIXME this is an unfortunate workaround for an Edge bug for selects with required:
-    // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8794503/
-    if (/edge\//i.test(window.navigator.userAgent)) {
-      let value = this.$().val();
-      this.$().val(`${value}-fake-edge-😳`);
-      this.$().val(value);
-    }
   },
 
   /**


### PR DESCRIPTION
This Edge hack is no longer necessary, as the bug it was
addressing has since been fixed:
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8794503/

I think it‘s safe to remove since Edge is evergreen, if I understand correctly?

See my [original PR](https://github.com/thefrontside/emberx-select/pull/169) for reference.