### PR TITLE
Prepare package and docs for adoption.

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,12 @@ known as emberx:
 * `ember test`
 * `ember test --server`
 
+## Release Process
+
+Every commit to master results in a build and push to the demo
+application at http://emberx-select.netlify.com
+
+Npm releases use semver and happen at the project owner's discretion.
 
 ## Code of Conduct
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "https://github.com/thefrontside/emberx-select",
+  "repository": "https://github.com/adopted-ember-addons/emberx-select",
   "scripts": {
     "bower-install": "bower install",
     "build": "ember build",


### PR DESCRIPTION
It's been a blast maintaining emberx-select, and indeed I think we've used it on every single Ember project we've done in the last 5 years.

This changes the repository to its new home, and documents the (admittedly very loose) release process according to the [transfer docuemntation][1]

[1]: https://github.com/adopted-ember-addons/program-guidelines/blob/master/README.md